### PR TITLE
update to Node.js 20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,5 +8,5 @@ inputs:
     description: 'a warning'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
```
pr-warning
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: hashicorp/pr-warning@v1.0.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
specifically from https://github.com/hashicorp/terraform-provider-google/actions/runs/9001656186